### PR TITLE
#0 is not a valid hashtag

### DIFF
--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -12,7 +12,7 @@ public class Regex {
 
   private static String LATIN_ACCENTS_CHARS = "\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u00ff";
   private static final String HASHTAG_ALPHA_CHARS = "a-z" + LATIN_ACCENTS_CHARS +
-                                                   "\\u0400-\\u04ff0\\u0500-\\u0527" + // Cyrillic
+                                                   "\\u0400-\\u04ff\\u0500-\\u0527" + // Cyrillic
                                                    "\\u1100-\\u11ff\\u3130-\\u3185\\uA960-\\uA97F\\uAC00-\\uD7AF\\uD7B0-\\uD7FF" + // Hangul (Korean)
                                                    "\\p{InHiragana}\\p{InKatakana}" + // Japanese Hiragana and Katakana
                                                    "\\p{InCJKUnifiedIdeographs}\\u3005" + // Japanese Kanji / Chinese Han

--- a/tests/com/twitter/RegexTest.java
+++ b/tests/com/twitter/RegexTest.java
@@ -15,6 +15,9 @@ public class RegexTest extends TestCase {
     assertTrue(Regex.AUTO_LINK_HASHTAGS.matcher("これはOK #ハッシュタグ").find());
     assertTrue(Regex.AUTO_LINK_HASHTAGS.matcher("これもOK。#ハッシュタグ").find());
     assertFalse(Regex.AUTO_LINK_HASHTAGS.matcher("これはダメ#ハッシュタグ").find());
+
+    assertFalse(Regex.AUTO_LINK_HASHTAGS.matcher("#123").find());
+    assertFalse(Regex.AUTO_LINK_HASHTAGS.matcher("#012").find());
   }
 
   public void testAutoLinkUsernamesOrLists() {

--- a/tests/com/twitter/RegexTest.java
+++ b/tests/com/twitter/RegexTest.java
@@ -16,8 +16,8 @@ public class RegexTest extends TestCase {
     assertTrue(Regex.AUTO_LINK_HASHTAGS.matcher("これもOK。#ハッシュタグ").find());
     assertFalse(Regex.AUTO_LINK_HASHTAGS.matcher("これはダメ#ハッシュタグ").find());
 
-    assertFalse(Regex.AUTO_LINK_HASHTAGS.matcher("#123").find());
-    assertFalse(Regex.AUTO_LINK_HASHTAGS.matcher("#012").find());
+    assertFalse(Regex.AUTO_LINK_HASHTAGS.matcher("#1").find());
+    assertFalse(Regex.AUTO_LINK_HASHTAGS.matcher("#0").find());
   }
 
   public void testAutoLinkUsernamesOrLists() {


### PR DESCRIPTION
Thank you for your open source library. We have used this to our service.

We should handle "#0" as invalid hashtag, but recent version doesn't so.
I hope that this patch will be help to fix.

Best,
