### PR TITLE
Don't extract URLs with control character

### DIFF
--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -43,6 +43,7 @@ public class Regex {
     "(?:" +                                                   // subdomains + domain + ccTLD
         URL_VALID_SUBDOMAIN + "+" + URL_VALID_DOMAIN_NAME +   // e.g. foo.co.jp, bar.co.uk
         URL_VALID_CCTLD +
+        "(?:\\." + URL_VALID_GTLD + ")?" +
       ")" +
     "|(?:" +                                                  // optional subdomains + domain + gTLD
       URL_VALID_SUBDOMAIN + "*" + URL_VALID_DOMAIN_NAME +     // e.g. twitter.com, www.twitter.com
@@ -57,25 +58,25 @@ public class Regex {
 
   private static final String URL_VALID_PORT_NUMBER = "[0-9]++";
 
-  private static final String URL_VALID_GENERAL_PATH_CHARS = "[a-z0-9!\\*';:=\\+\\$/%#\\[\\]\\-_,~\\.\\|&" + LATIN_ACCENTS_CHARS + "]";
-  private static final String URL_VALID_URL_PATH_ENDING_CHARS = "[a-z0-9=_#/\\-\\+" + LATIN_ACCENTS_CHARS +"]";
-  private static final String URL_VALID_PATH_CHARS_WITHOUT_SLASH = "[" + URL_VALID_GENERAL_PATH_CHARS + "&&[^/]]";
-  private static final String URL_VALID_PATH_CHARS_WITHOUT_COMMA = "[" + URL_VALID_GENERAL_PATH_CHARS + "&&[^,.]]";
-
+  private static final String URL_VALID_GENERAL_PATH_CHARS = "[a-z0-9!\\*';:=\\+,.\\$/%#\\[\\]\\-_~\\|&" + LATIN_ACCENTS_CHARS + "]";
   /** Allow URL paths to contain balanced parens
    *  1. Used in Wikipedia URLs like /Primer_(film)
    *  2. Used in IIS sessions like /S(dfd346)/
   **/
-  private static final String URL_BALANCE_PARENS = "(?:\\(" + URL_VALID_GENERAL_PATH_CHARS + "+\\))";
-  private static final String URL_VALID_URL_PATH_CHARS = "(?:" +
-    URL_BALANCE_PARENS +
-    "|@" + URL_VALID_PATH_CHARS_WITHOUT_SLASH + "++/" +
-    "|(?:[.,]*+" + URL_VALID_PATH_CHARS_WITHOUT_COMMA + "*" + URL_VALID_URL_PATH_ENDING_CHARS + ")++" +
-  ")";
-
+  private static final String URL_BALANCED_PARENS = "\\(" + URL_VALID_GENERAL_PATH_CHARS + "+\\)";
   /** Valid end-of-path chracters (so /foo. does not gobble the period).
    *   2. Allow =&# for empty URL parameters and other URL-join artifacts
   **/
+  private static final String URL_VALID_PATH_ENDING_CHARS = "[a-z0-9=_#/\\-\\+" + LATIN_ACCENTS_CHARS + "]|(?:" + URL_BALANCED_PARENS +")";
+
+  private static final String URL_VALID_PATH = "(?:" +
+    "(?:" +
+      URL_VALID_GENERAL_PATH_CHARS + "*" +
+      "(?:" + URL_BALANCED_PARENS + URL_VALID_GENERAL_PATH_CHARS + "*)*" +
+      URL_VALID_PATH_ENDING_CHARS +
+    ")|(?:@" + URL_VALID_GENERAL_PATH_CHARS + "+/)" +
+  ")";
+
   private static final String URL_VALID_URL_QUERY_CHARS = "[a-z0-9!\\*'\\(\\);:&=\\+\\$/%#\\[\\]\\-_\\.,~\\|]";
   private static final String URL_VALID_URL_QUERY_ENDING_CHARS = "[a-z0-9_&=#/]";
   private static final String VALID_URL_PATTERN_STRING =
@@ -86,10 +87,7 @@ public class Regex {
       "(" + URL_VALID_DOMAIN + ")" +                               //  $5 Domain(s)
       "(?::(" + URL_VALID_PORT_NUMBER +"))?" +                     //  $6 Port number (optional)
       "(/" +
-        "(?:" +
-          URL_VALID_URL_PATH_CHARS + "+|" +                        //     1+ path chars and a valid last char
-          URL_VALID_URL_PATH_ENDING_CHARS +                        //     Just a # case
-        ")?" +
+        URL_VALID_PATH + "*" +
       ")?" +                                                       //  $7 URL Path and anchor
       "(\\?" + URL_VALID_URL_QUERY_CHARS + "*" +                   //  $8 Query String
               URL_VALID_URL_QUERY_ENDING_CHARS + ")?" +

--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -20,11 +20,12 @@ public class Regex {
   private static final String HASHTAG_ALPHA_NUMERIC = "[" + HASHTAG_ALPHA_NUMERIC_CHARS +"]";
 
   /* URL related hash regex collection */
-  private static final String URL_VALID_PRECEEDING_CHARS = "(?:[^\\-/\"'!=A-Z0-9_@＠.\\p{InGeneralPunctuation}]|^)";
+  private static final String URL_VALID_PRECEEDING_CHARS = "(?:[^\\-/\"'!=A-Z0-9_@＠.]|^)";
 
-  private static final String URL_VALID_CHARS = "[^\\p{Punct}\\s\\p{Zs}\\p{InGeneralPunctuation}]";
-  private static final String URL_VALID_SUBDOMAIN = "(?:(?:" + URL_VALID_CHARS + "[_-" + URL_VALID_CHARS + "]*)?" + URL_VALID_CHARS + "\\.)";
-  private static final String URL_VALID_DOMAIN_NAME = "(?:(?:" + URL_VALID_CHARS + "[-" + URL_VALID_CHARS + "]*)?" + URL_VALID_CHARS + "\\.)";
+  private static final String URL_VALID_CHARS = "[\\p{Alnum}" + LATIN_ACCENTS_CHARS + "]";
+  private static final String URL_VALID_SUBDOMAIN = "(?:(?:" + URL_VALID_CHARS + "[" + URL_VALID_CHARS + "\\-_]*)?" + URL_VALID_CHARS + "\\.)";
+  private static final String URL_VALID_DOMAIN_NAME = "(?:(?:" + URL_VALID_CHARS + "[" + URL_VALID_CHARS + "\\-]*)?" + URL_VALID_CHARS + "\\.)";
+  private static final String URL_VALID_UNICODE_CHARS = "[.[^\\p{Punct}\\s\\p{Zs}\\p{InGeneralPunctuation}]]";
 
   private static final String URL_VALID_GTLD =
       "(?:(?:aero|asia|biz|cat|com|coop|edu|gov|info|int|jobs|mil|mobi|museum|name|net|org|pro|tel|travel)(?=\\P{Alpha}|$))";
@@ -40,17 +41,17 @@ public class Regex {
   private static final String URL_PUNYCODE = "(?:xn--[0-9a-z]+)";
 
   private static final String URL_VALID_DOMAIN =
-    "(?:" +                                                   // subdomains + domain + ccTLD
-        URL_VALID_SUBDOMAIN + "+" + URL_VALID_DOMAIN_NAME +   // e.g. foo.co.jp, bar.co.uk
-        URL_VALID_CCTLD +
-        "(?:\\." + URL_VALID_GTLD + ")?" +
+    "(?:" +                                                   // subdomains + domain + TLD
+        URL_VALID_SUBDOMAIN + "+" + URL_VALID_DOMAIN_NAME +   // e.g. www.twitter.com, foo.co.jp, bar.co.uk
+        "(?:" + URL_VALID_GTLD + "|" + URL_VALID_CCTLD + "|" + URL_PUNYCODE + ")" +
       ")" +
-    "|(?:" +                                                  // optional subdomains + domain + gTLD
-      URL_VALID_SUBDOMAIN + "*" + URL_VALID_DOMAIN_NAME +     // e.g. twitter.com, www.twitter.com
+    "|(?:" +                                                  // domain + gTLD
+      URL_VALID_DOMAIN_NAME +                                 // e.g. twitter.com
       "(?:" + URL_VALID_GTLD + "|" + URL_PUNYCODE + ")" +
     ")" +
     "|(?:" + "(?<=https?://)" +                               // protocol + domain + ccTLD
-      URL_VALID_DOMAIN_NAME + URL_VALID_CCTLD +               // e.g. http://t.co
+      "(?:(?:" + URL_VALID_DOMAIN_NAME + URL_VALID_CCTLD + ")" + // e.g. http://t.co
+      "|(?:" + URL_VALID_UNICODE_CHARS + "+\\.(?:" + URL_VALID_GTLD + "|" + URL_VALID_CCTLD + ")))" +
     ")" +
     "|(?:" +                                                  // domain + ccTLD + '/'
       URL_VALID_DOMAIN_NAME + URL_VALID_CCTLD + "(?=/)" +     // e.g. t.co/

--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -20,9 +20,9 @@ public class Regex {
   private static final String HASHTAG_ALPHA_NUMERIC = "[" + HASHTAG_ALPHA_NUMERIC_CHARS +"]";
 
   /* URL related hash regex collection */
-  private static final String URL_VALID_PRECEEDING_CHARS = "(?:[^\\-/\"'!=A-Z0-9_@＠.]|^)";
+  private static final String URL_VALID_PRECEEDING_CHARS = "(?:[^\\-/\"'!=A-Z0-9_@＠.\\p{InGeneralPunctuation}]|^)";
 
-  private static final String URL_VALID_CHARS = "[^\\p{Punct}\\s\\u00a0]";
+  private static final String URL_VALID_CHARS = "[^\\p{Punct}\\s\\p{Zs}\\p{InGeneralPunctuation}]";
   private static final String URL_VALID_SUBDOMAIN = "(?:(?:" + URL_VALID_CHARS + "[_-" + URL_VALID_CHARS + "]*)?" + URL_VALID_CHARS + "\\.)";
   private static final String URL_VALID_DOMAIN_NAME = "(?:(?:" + URL_VALID_CHARS + "[-" + URL_VALID_CHARS + "]*)?" + URL_VALID_CHARS + "\\.)";
 

--- a/tests/com/twitter/ExtractorTest.java
+++ b/tests/com/twitter/ExtractorTest.java
@@ -118,9 +118,10 @@ public class ExtractorTest extends TestCase {
    }
 
    public void testUrlWithoutProtocol() {
-     String text = "www.twitter.com, www.yahoo.co.jp, t.co/blahblah";
+     String text = "www.twitter.com, www.yahoo.co.jp, t.co/blahblah, www.poloshirts.uk.com";
      assertList("Failed to extract URLs without protocol",
-         new String[]{"www.twitter.com", "www.yahoo.co.jp", "t.co/blahblah"}, extractor.extractURLs(text));
+         new String[]{"www.twitter.com", "www.yahoo.co.jp", "t.co/blahblah", "www.poloshirts.uk.com"},
+         extractor.extractURLs(text));
 
      List<Extractor.Entity> extracted = extractor.extractURLsWithIndices(text);
      assertEquals(extracted.get(0).getStart().intValue(), 0);

--- a/tests/com/twitter/RegexTest.java
+++ b/tests/com/twitter/RegexTest.java
@@ -47,7 +47,7 @@ public class RegexTest extends TestCase {
     assertTrue("Matching a repeated path end should take less than 10ms (took " + duration + "ms)", (duration < 10) );
   }
 
-  public void testVAlidURLWithoutProtocol() {
+  public void testValidURLWithoutProtocol() {
     assertTrue("Matching a URL with gTLD without protocol.",
         Regex.VALID_URL.matcher("twitter.com").matches());
 
@@ -68,6 +68,14 @@ public class RegexTest extends TestCase {
 
     assertTrue("Match a short URL with ccTLD and '/' but without protocol.",
         Regex.VALID_URL.matcher("t.co/blahblah").matches());
+  }
+
+  public void testInvalidUrlWithInvalidCharacter() {
+    char[] invalid_chars = new char[]{'\u202A', '\u202B', '\u202C', '\u202D', '\u202E'};
+    for (char c : invalid_chars) {
+      assertFalse("Should not extract URLs with invalid character",
+          Regex.VALID_URL.matcher("http://twitt" + c + "er").matches());
+    }
   }
 
   public void testExtractMentions() {

--- a/tests/com/twitter/RegexTest.java
+++ b/tests/com/twitter/RegexTest.java
@@ -74,7 +74,7 @@ public class RegexTest extends TestCase {
     char[] invalid_chars = new char[]{'\u202A', '\u202B', '\u202C', '\u202D', '\u202E'};
     for (char c : invalid_chars) {
       assertFalse("Should not extract URLs with invalid character",
-          Regex.VALID_URL.matcher("http://twitt" + c + "er").matches());
+          Regex.VALID_URL.matcher("http://twitt" + c + "er").find());
     }
   }
 


### PR DESCRIPTION
Don't extract URLs which contain control character (e.g., \U+202A ~ \U+202F)
