### PR TITLE
Dont extract in hash

### DIFF
--- a/src/com/twitter/Autolink.java
+++ b/src/com/twitter/Autolink.java
@@ -106,7 +106,7 @@ public class Autolink {
               matcher.group(Regex.AUTO_LINK_USERNAME_OR_LISTS_GROUP_LIST).equals("")) {
 
             // Username only
-            if (! Regex.SCREEN_NAME_MATCH_END.matcher(text.substring(matcher.end())).find()) {
+            if (! Regex.SCREEN_NAME_MATCH_END.matcher(chunks[i].substring(matcher.end())).find()) {
               matcher.appendReplacement(sb,
                 String.format("$%s$%s<a class=\"%s %s\" href=\"%s$%s\"%s>$%s</a>",
                 Regex.AUTO_LINK_USERNAME_OR_LISTS_GROUP_BEFORE,
@@ -169,7 +169,21 @@ public class Autolink {
     }
     replacement.append(">$").append(Regex.AUTO_LINK_HASHTAGS_GROUP_HASH).append("$")
                .append(Regex.AUTO_LINK_HASHTAGS_GROUP_TAG).append("</a>");
-    return Regex.AUTO_LINK_HASHTAGS.matcher(text).replaceAll(replacement.toString());
+
+    StringBuffer sb = new StringBuffer(text.length());
+    Matcher matcher = Regex.AUTO_LINK_HASHTAGS.matcher(text);
+    while (matcher.find()) {
+      String after = text.substring(matcher.end());
+      if (!Regex.HASHTAG_MATCH_END.matcher(after).find()) {
+        matcher.appendReplacement(sb, replacement.toString());
+      } else {
+        // not a valid hashtag
+        matcher.appendReplacement(sb, "$0");
+      }
+    }
+    matcher.appendTail(sb);
+
+    return sb.toString();
   }
 
   /**

--- a/src/com/twitter/Extractor.java
+++ b/src/com/twitter/Extractor.java
@@ -97,7 +97,8 @@ public class Extractor {
     List<String> extracted = new ArrayList<String>();
     Matcher matcher = Regex.EXTRACT_MENTIONS.matcher(text);
     while (matcher.find()) {
-      if (! Regex.SCREEN_NAME_MATCH_END.matcher(matcher.group(Regex.EXTRACT_MENTIONS_GROUP_AFTER)).matches()) {
+      String after = text.substring(matcher.end());
+      if (! Regex.SCREEN_NAME_MATCH_END.matcher(after).find()) {
         extracted.add(matcher.group(Regex.EXTRACT_MENTIONS_GROUP_USERNAME));
       }
     }
@@ -118,7 +119,8 @@ public class Extractor {
     List<Entity> extracted = new ArrayList<Entity>();
     Matcher matcher = Regex.EXTRACT_MENTIONS.matcher(text);
     while (matcher.find()) {
-      if (! Regex.SCREEN_NAME_MATCH_END.matcher(matcher.group(Regex.EXTRACT_MENTIONS_GROUP_AFTER)).matches()) {
+      String after = text.substring(matcher.end());
+      if (! Regex.SCREEN_NAME_MATCH_END.matcher(after).find()) {
         extracted.add(new Entity(matcher, "mention", Regex.EXTRACT_MENTIONS_GROUP_USERNAME));
       }
     }
@@ -139,8 +141,13 @@ public class Extractor {
     }
 
     Matcher matcher = Regex.EXTRACT_REPLY.matcher(text);
-    if (matcher.matches()) {
-      return matcher.group(Regex.EXTRACT_REPLY_GROUP_USERNAME);
+    if (matcher.find()) {
+      String after = text.substring(matcher.end());
+      if (Regex.SCREEN_NAME_MATCH_END.matcher(after).find()) {
+        return null;
+      } else {
+        return matcher.group(Regex.EXTRACT_REPLY_GROUP_USERNAME);
+      }
     } else {
       return null;
     }
@@ -229,7 +236,10 @@ public class Extractor {
     List<String> extracted = new ArrayList<String>();
     Matcher matcher = pattern.matcher(text);
     while (matcher.find()) {
-      extracted.add(matcher.group(groupNumber));
+      String after = text.substring(matcher.end());
+      if (!Regex.HASHTAG_MATCH_END.matcher(after).find()) {
+        extracted.add(matcher.group(groupNumber));
+      }
     }
     return extracted;
   }

--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -107,12 +107,11 @@ public class Regex {
   /* Begin public constants */
   public static final Pattern AT_SIGNS = Pattern.compile("[" + AT_SIGNS_CHARS + "]");
 
-  public static final Pattern SCREEN_NAME_MATCH_END = Pattern.compile("^(?:[" + AT_SIGNS_CHARS + LATIN_ACCENTS_CHARS + "]|://)");
-
   public static final Pattern AUTO_LINK_HASHTAGS = Pattern.compile("(^|[^&/" + HASHTAG_ALPHA_NUMERIC_CHARS + "]+)(#|\uFF03)(" + HASHTAG_ALPHA_NUMERIC + "*" + HASHTAG_ALPHA + HASHTAG_ALPHA_NUMERIC + "*)", Pattern.CASE_INSENSITIVE);
   public static final int AUTO_LINK_HASHTAGS_GROUP_BEFORE = 1;
   public static final int AUTO_LINK_HASHTAGS_GROUP_HASH = 2;
   public static final int AUTO_LINK_HASHTAGS_GROUP_TAG = 3;
+  public static final Pattern HASHTAG_MATCH_END = Pattern.compile("^(?:[#＃]|://)");
 
   public static final Pattern AUTO_LINK_USERNAMES_OR_LISTS = Pattern.compile("([^a-z0-9_]|^|RT:?)(" + AT_SIGNS + "+)([a-z0-9_]{1,20})(/[a-z][a-z0-9_\\-]{0,24})?", Pattern.CASE_INSENSITIVE);
   public static final int AUTO_LINK_USERNAME_OR_LISTS_GROUP_BEFORE = 1;
@@ -130,11 +129,12 @@ public class Regex {
   public static final int VALID_URL_GROUP_PATH         = 7;
   public static final int VALID_URL_GROUP_QUERY_STRING = 8;
 
-  public static final Pattern EXTRACT_MENTIONS = Pattern.compile("(^|[^a-z0-9_])" + AT_SIGNS + "([a-z0-9_]{1,20})(?=(.|$))", Pattern.CASE_INSENSITIVE);
+  public static final Pattern EXTRACT_MENTIONS = Pattern.compile("(^|[^a-z0-9_])" + AT_SIGNS + "([a-z0-9_]{1,20})", Pattern.CASE_INSENSITIVE);
   public static final int EXTRACT_MENTIONS_GROUP_BEFORE = 1;
   public static final int EXTRACT_MENTIONS_GROUP_USERNAME = 2;
-  public static final int EXTRACT_MENTIONS_GROUP_AFTER = 3;
 
-  public static final Pattern EXTRACT_REPLY = Pattern.compile("^(?:[" + com.twitter.regex.Spaces.getCharacterClass() + "])*" + AT_SIGNS + "([a-z0-9_]{1,20}).*", Pattern.CASE_INSENSITIVE);
+  public static final Pattern EXTRACT_REPLY = Pattern.compile("^(?:[" + com.twitter.regex.Spaces.getCharacterClass() + "])*" + AT_SIGNS + "([a-z0-9_]{1,20})", Pattern.CASE_INSENSITIVE);
   public static final int EXTRACT_REPLY_GROUP_USERNAME = 1;
+
+  public static final Pattern SCREEN_NAME_MATCH_END = Pattern.compile("^(?:[" + AT_SIGNS_CHARS + LATIN_ACCENTS_CHARS + "]|://)");
 }

--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -20,7 +20,7 @@ public class Regex {
   private static final String HASHTAG_ALPHA_NUMERIC = "[" + HASHTAG_ALPHA_NUMERIC_CHARS +"]";
 
   /* URL related hash regex collection */
-  private static final String URL_VALID_PRECEEDING_CHARS = "(?:[^\\-/\"'!=A-Z0-9_@＠.\u202A-\u202E]|^)";
+  private static final String URL_VALID_PRECEEDING_CHARS = "(?:[^\\-/\"'!=A-Z0-9_@＠#＃.\u202A-\u202E]|^)";
 
   private static final String URL_VALID_CHARS = "[\\p{Alnum}" + LATIN_ACCENTS_CHARS + "]";
   private static final String URL_VALID_SUBDOMAIN = "(?:(?:" + URL_VALID_CHARS + "[" + URL_VALID_CHARS + "\\-_]*)?" + URL_VALID_CHARS + "\\.)";

--- a/tests/com/twitter/RegexTest.java
+++ b/tests/com/twitter/RegexTest.java
@@ -79,7 +79,7 @@ public class RegexTest extends TestCase {
   }
 
   public void testExtractMentions() {
-    assertCaptureCount(3, Regex.EXTRACT_MENTIONS, "sample @user mention");
+    assertCaptureCount(2, Regex.EXTRACT_MENTIONS, "sample @user mention");
   }
 
   public void testExtractReply() {


### PR DESCRIPTION
The current twitter-text tries to extract URL in a hashtag. For example, it extract "test.com" as a URL from a text "#test.com"

With this change, twitter-text won't extract URL in a hashtag.
