### PR TITLE
Fix a bug in VALID_URL regex which freezes when trying to match URL followed by punctuations.

### DIFF
--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -94,7 +94,7 @@ public class Regex {
       "(" + URL_VALID_DOMAIN + ")" +                               //  $5 Domain(s)
       "(?::(" + URL_VALID_PORT_NUMBER +"))?" +                     //  $6 Port number (optional)
       "(/" +
-        URL_VALID_PATH + "*" +
+        URL_VALID_PATH + "*+" +
       ")?" +                                                       //  $7 URL Path and anchor
       "(\\?" + URL_VALID_URL_QUERY_CHARS + "*" +                   //  $8 Query String
               URL_VALID_URL_QUERY_ENDING_CHARS + ")?" +

--- a/tests/com/twitter/ExtractorTest.java
+++ b/tests/com/twitter/ExtractorTest.java
@@ -132,12 +132,20 @@ public class ExtractorTest extends TestCase {
      assertEquals(extracted.get(2).getEnd().intValue(), 47);
    }
 
+   public void testURLFollowedByPunctuations() {
+     String text ="http://games.aarp.org/games/mahjongg-dimensions.aspx!!!!!!";
+     assertList("Failed to extract URLs followed by punctuations",
+         new String[]{"http://games.aarp.org/games/mahjongg-dimensions.aspx"},
+         extractor.extractURLs(text));
+   }
+
    public void testUrlWithPunctuation() {
      String[] urls = new String[] {
        "http://www.foo.com/foo/path-with-period./",
        "http://www.foo.org.za/foo/bar/688.1",
        "http://www.foo.com/bar-path/some.stm?param1=foo;param2=P1|0||P2|0",
        "http://foo.com/bar/123/foo_&_bar/",
+       "http://foo.com/bar(test)bar(test)bar(test)",
        "www.foo.com/foo/path-with-period./",
        "www.foo.org.za/foo/bar/688.1",
        "www.foo.com/bar-path/some.stm?param1=foo;param2=P1|0||P2|0",

--- a/tests/com/twitter/RegexTest.java
+++ b/tests/com/twitter/RegexTest.java
@@ -34,17 +34,22 @@ public class RegexTest extends TestCase {
   }
 
   public void testValidUrlDoesNotTakeForeverOnRepeatedPuctuationAtEnd() {
-    String repeatedPath = "Try http://example.com/path**********************";
+    String[] repeatedPaths = {
+        "Try http://example.com/path**********************",
+        "http://foo.org/bar/foo-bar-foo-bar.aspx!!!!!! Test"
+    };
 
-    long start = System.currentTimeMillis();
-    Matcher matcher = Regex.VALID_URL.matcher(repeatedPath);
-    boolean isValid = matcher.find();
-    long end = System.currentTimeMillis();
+    for (String text : repeatedPaths) {
+      long start = System.currentTimeMillis();
+      boolean isValid = Regex.VALID_URL.matcher(text).find();
+      Regex.VALID_URL.matcher(text).matches();
+      long end = System.currentTimeMillis();
 
-    assertTrue("Repeated puctuation should still produce a valid URL", isValid);
+      assertTrue("Should be able to extract a valid URL even followed by punctuations", isValid);
 
-    long duration = (end - start);
-    assertTrue("Matching a repeated path end should take less than 10ms (took " + duration + "ms)", (duration < 10) );
+      long duration = (end - start);
+      assertTrue("Matching a repeated path end should take less than 10ms (took " + duration + "ms)", (duration < 10) );
+    }
   }
 
   public void testValidURLWithoutProtocol() {


### PR DESCRIPTION
The current VALID_URL regex freezes when match() is called with URL followed by punctuations. (It returns fine for find()). This will fix it so that both match() and find() return immediately.
