### PR TITLE
Allow Japanese Ditto mark and Turkish 'i' in hashtag.

### DIFF
--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -4,14 +4,14 @@ package com.twitter;
 import java.util.regex.*;
 
 public class Regex {
-  private static String LATIN_ACCENTS_CHARS = "\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u00ff\\u015f";
+  private static String LATIN_ACCENTS_CHARS = "\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u00ff\\u0130-\\u0131\\u015f";
   private static final String HASHTAG_ALPHA_CHARS = "a-z" + LATIN_ACCENTS_CHARS +
                                                    "\\u0400-\\u04ff\\u0500-\\u0527" +  // Cyrillic
                                                    "\\u2de0–\\u2dff\\ua640–\\ua69f" +  // Cyrillic Extended A/B
                                                    "\\u1100-\\u11ff\\u3130-\\u3185\\uA960-\\uA97F\\uAC00-\\uD7AF\\uD7B0-\\uD7FF" + // Hangul (Korean)
                                                    "\\p{InHiragana}\\p{InKatakana}" +  // Japanese Hiragana and Katakana
                                                    "\\p{InCJKUnifiedIdeographs}" +     // Japanese Kanji / Chinese Han
-                                                   "\\u3005\\u303b" +                  // Kanji/Han iteration marks
+                                                   "\\u3003\\u3005\\u303b" +           // Kanji/Han iteration marks
                                                    "\\uff21-\\uff3a\\uff41-\\uff5a" +  // full width Alphabet
                                                    "\\uff66-\\uff9f" +                 // half width Katakana
                                                    "\\uffa1-\\uffdc";                  // half width Hangul (Korean)


### PR DESCRIPTION
This will allow Japanese Ditto mark (〃, U+3003) and Turkish 'i' (ı, U+131 and İ, U+130) in hashtag.
