### PR TITLE
improve autoLinkHashtags compatibility with IE

### DIFF
--- a/src/com/twitter/Autolink.java
+++ b/src/com/twitter/Autolink.java
@@ -23,7 +23,7 @@ public class Autolink {
   /** Default href for list links (the username/list without the @ will be appended) */
   public static final String DEFAULT_LIST_URL_BASE = "http://twitter.com/";
   /** Default href for hashtag links (the hashtag without the # will be appended) */
-  public static final String DEFAULT_HASHTAG_URL_BASE = "http://twitter.com/search?q=%23";
+  public static final String DEFAULT_HASHTAG_URL_BASE = "http://twitter.com/#!/search?q=%23";
   /** HTML attribute to add when noFollow is true (default) */
   public static final String NO_FOLLOW_HTML_ATTRIBUTE = " rel=\"nofollow\"";
 

--- a/tests/com/twitter/AutolinkTest.java
+++ b/tests/com/twitter/AutolinkTest.java
@@ -14,14 +14,14 @@ public class AutolinkTest extends TestCase {
 
   public void testNoFollowByDefault() {
     String tweet = "This has a #hashtag";
-    String expected = "This has a <a href=\"http://twitter.com/search?q=%23hashtag\" title=\"#hashtag\" class=\"tweet-url hashtag\" rel=\"nofollow\">#hashtag</a>";
+    String expected = "This has a <a href=\"http://twitter.com/#!/search?q=%23hashtag\" title=\"#hashtag\" class=\"tweet-url hashtag\" rel=\"nofollow\">#hashtag</a>";
     assertAutolink(expected, linker.autoLinkHashtags(tweet));
   }
 
   public void testNoFollowDisabled() {
     linker.setNoFollow(false);
     String tweet = "This has a #hashtag";
-    String expected = "This has a <a href=\"http://twitter.com/search?q=%23hashtag\" title=\"#hashtag\" class=\"tweet-url hashtag\">#hashtag</a>";
+    String expected = "This has a <a href=\"http://twitter.com/#!/search?q=%23hashtag\" title=\"#hashtag\" class=\"tweet-url hashtag\">#hashtag</a>";
     assertAutolink(expected, linker.autoLinkHashtags(tweet));
   }
 
@@ -51,7 +51,7 @@ public class AutolinkTest extends TestCase {
   public void testWithAngleBrackets() {
     linker.setNoFollow(false);
     String tweet = "(Debugging) <3 #idol2011";
-    String expected = "(Debugging) &lt;3 <a href=\"http://twitter.com/search?q=%23idol2011\" title=\"#idol2011\" class=\"tweet-url hashtag\">#idol2011</a>";
+    String expected = "(Debugging) &lt;3 <a href=\"http://twitter.com/#!/search?q=%23idol2011\" title=\"#idol2011\" class=\"tweet-url hashtag\">#idol2011</a>";
     assertAutolink(expected, linker.autoLink(tweet));
   }
 


### PR DESCRIPTION
This corresponds to the following pull request in twitter-text-js.
https://github.com/twitter/twitter-text-js/pull/28
