### PR TITLE
Extract mentions slightly more strictly

### DIFF
--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -131,7 +131,7 @@ public class Regex {
 
   public static final Pattern VALID_TCO_URL = Pattern.compile("^https?:\\/\\/t\\.co\\/[a-z0-9]+", Pattern.CASE_INSENSITIVE);
 
-  public static final Pattern EXTRACT_MENTIONS = Pattern.compile("(^|[^a-z0-9_])" + AT_SIGNS + "([a-z0-9_]{1,20})", Pattern.CASE_INSENSITIVE);
+  public static final Pattern EXTRACT_MENTIONS = Pattern.compile("(^|[^a-z0-9_!#$%&*" + AT_SIGNS_CHARS + "])" + AT_SIGNS + "([a-z0-9_]{1,20})", Pattern.CASE_INSENSITIVE);
   public static final int EXTRACT_MENTIONS_GROUP_BEFORE = 1;
   public static final int EXTRACT_MENTIONS_GROUP_USERNAME = 2;
 

--- a/tests/com/twitter/RegexTest.java
+++ b/tests/com/twitter/RegexTest.java
@@ -85,13 +85,13 @@ public class RegexTest extends TestCase {
 
   public void testExtractMentions() {
     assertCaptureCount(2, Regex.EXTRACT_MENTIONS, "sample @user mention");
-    assertFalse("Failed to ignore unintended mention precedented by !", Regex.EXTRACT_MENTIONS.matcher("f!@kn").find());
-    assertFalse("Failed to ignore unintended mention precedented by @", Regex.EXTRACT_MENTIONS.matcher("f@@kn").find());
-    assertFalse("Failed to ignore unintended mention precedented by #", Regex.EXTRACT_MENTIONS.matcher("f#@kn").find());
-    assertFalse("Failed to ignore unintended mention precedented by $", Regex.EXTRACT_MENTIONS.matcher("f$@kn").find());
-    assertFalse("Failed to ignore unintended mention precedented by %", Regex.EXTRACT_MENTIONS.matcher("f%@kn").find());
-    assertFalse("Failed to ignore unintended mention precedented by &", Regex.EXTRACT_MENTIONS.matcher("f&@kn").find());
-    assertFalse("Failed to ignore unintended mention precedented by *", Regex.EXTRACT_MENTIONS.matcher("f*@kn").find());
+  }
+
+  public void testInvalidMentions() {
+    char[] invalid_chars = new char[]{'!', '@', '#', '$', '%', '&', '*'};
+    for (char c : invalid_chars) {
+      assertFalse("Failed to ignore unintended mention precedented by " + c, Regex.EXTRACT_MENTIONS.matcher("f" + c + "@kn").find());
+    }
   }
 
   public void testExtractReply() {

--- a/tests/com/twitter/RegexTest.java
+++ b/tests/com/twitter/RegexTest.java
@@ -85,6 +85,13 @@ public class RegexTest extends TestCase {
 
   public void testExtractMentions() {
     assertCaptureCount(2, Regex.EXTRACT_MENTIONS, "sample @user mention");
+    assertFalse("Failed to ignore unintended mention precedented by !", Regex.EXTRACT_MENTIONS.matcher("f!@kn").find());
+    assertFalse("Failed to ignore unintended mention precedented by @", Regex.EXTRACT_MENTIONS.matcher("f@@kn").find());
+    assertFalse("Failed to ignore unintended mention precedented by #", Regex.EXTRACT_MENTIONS.matcher("f#@kn").find());
+    assertFalse("Failed to ignore unintended mention precedented by $", Regex.EXTRACT_MENTIONS.matcher("f$@kn").find());
+    assertFalse("Failed to ignore unintended mention precedented by %", Regex.EXTRACT_MENTIONS.matcher("f%@kn").find());
+    assertFalse("Failed to ignore unintended mention precedented by &", Regex.EXTRACT_MENTIONS.matcher("f&@kn").find());
+    assertFalse("Failed to ignore unintended mention precedented by *", Regex.EXTRACT_MENTIONS.matcher("f*@kn").find());
   }
 
   public void testExtractReply() {

--- a/tests/com/twitter/RegexTest.java
+++ b/tests/com/twitter/RegexTest.java
@@ -90,7 +90,7 @@ public class RegexTest extends TestCase {
   public void testInvalidMentions() {
     char[] invalid_chars = new char[]{'!', '@', '#', '$', '%', '&', '*'};
     for (char c : invalid_chars) {
-      assertFalse("Failed to ignore unintended mention precedented by " + c, Regex.EXTRACT_MENTIONS.matcher("f" + c + "@kn").find());
+      assertFalse("Failed to ignore a mention preceded by " + c, Regex.EXTRACT_MENTIONS.matcher("f" + c + "@kn").find());
     }
   }
 


### PR DESCRIPTION
I made extraction of mentions slightly more strict.
Now it does not extract mentions precedented by !, @, #, $, %, & and .
This avoids extracting unintended mentions like "f@KN", which, in turn, reduces spams in users mention section.
