### PR TITLE
Add Extractor.modifyIndices{FromUTF16ToUnicode, FromUnicodeToUTF16}

### DIFF
--- a/src/com/twitter/Autolink.java
+++ b/src/com/twitter/Autolink.java
@@ -62,6 +62,7 @@ public class Autolink {
     hashtagUrlBase = DEFAULT_HASHTAG_URL_BASE;
 
     extractor.setExtractURLWithoutProtocol(false);
+    extractor.setCountSupplementaryCharacterAsOne(false);
   }
 
   public String escapeBrackets(String text) {
@@ -85,6 +86,9 @@ public class Autolink {
   private String autoLinkEntities(String text, List<Entity> entities) {
     StringBuilder builder = new StringBuilder(text.length());
     int beginIndex = 0;
+
+    // adjust indices for Unicode supplementary characters
+    extractor.adjustIndices(text, entities, 1);
 
     for (Entity entity : entities) {
       builder.append(text.subSequence(beginIndex, entity.start));
@@ -330,5 +334,16 @@ public class Autolink {
    */
   public void setUsernameIncludeSymbol(boolean usernameIncludeSymbol) {
     this.usernameIncludeSymbol = usernameIncludeSymbol;
+  }
+
+  /**
+   * Specifies whether Unicode supplemental characters (which are represented
+   * as 2 characters in Java) were counted as single characters when entities
+   * were extracted.
+   *
+   * @param flag  true to count supplementary characters as single characters.
+   */
+  public void setCountSupplementaryCharacterAsOne(boolean flag) {
+    extractor.setCountSupplementaryCharacterAsOne(flag);
   }
 }

--- a/src/com/twitter/Autolink.java
+++ b/src/com/twitter/Autolink.java
@@ -62,7 +62,6 @@ public class Autolink {
     hashtagUrlBase = DEFAULT_HASHTAG_URL_BASE;
 
     extractor.setExtractURLWithoutProtocol(false);
-    extractor.setCountSupplementaryCharacterAsOne(false);
   }
 
   public String escapeBrackets(String text) {
@@ -86,9 +85,6 @@ public class Autolink {
   private String autoLinkEntities(String text, List<Entity> entities) {
     StringBuilder builder = new StringBuilder(text.length());
     int beginIndex = 0;
-
-    // adjust indices for Unicode supplementary characters
-    extractor.adjustIndices(text, entities, 1);
 
     for (Entity entity : entities) {
       builder.append(text.subSequence(beginIndex, entity.start));
@@ -334,16 +330,5 @@ public class Autolink {
    */
   public void setUsernameIncludeSymbol(boolean usernameIncludeSymbol) {
     this.usernameIncludeSymbol = usernameIncludeSymbol;
-  }
-
-  /**
-   * Specifies whether Unicode supplemental characters (which are represented
-   * as 2 characters in Java) were counted as single characters when entities
-   * were extracted.
-   *
-   * @param flag  true to count supplementary characters as single characters.
-   */
-  public void setCountSupplementaryCharacterAsOne(boolean flag) {
-    extractor.setCountSupplementaryCharacterAsOne(flag);
   }
 }

--- a/src/com/twitter/Extractor.java
+++ b/src/com/twitter/Extractor.java
@@ -88,8 +88,6 @@ public class Extractor {
 
   protected boolean extractURLWithoutProtocol = true;
 
-  protected boolean countSupplementaryCharacterAsOne = true;
-
   /**
    * Create a new extractor.
    */
@@ -193,7 +191,6 @@ public class Extractor {
       }
     }
 
-    adjustIndices(text, extracted, -1);
     return extracted;
   }
 
@@ -278,7 +275,6 @@ public class Extractor {
       urls.add(new Entity(start, end, url, Entity.Type.URL));
     }
 
-    adjustIndices(text, urls, -1);
     return urls;
   }
 
@@ -334,8 +330,31 @@ public class Extractor {
       }
     }
 
-    adjustIndices(text, extracted, -1);
     return extracted;
+  }
+
+  /*
+   * Modify Unicode-based indices of the entities to UTF-16 based indices.
+   *
+   * In UTF-16 based indices, Unicode supplementary characters are counted as two characters.
+   *
+   * @param text original text
+   * @param entities entities with Unicode based indices
+   */
+  public void modifyIndicesFromUnicodeToUTF16(String text, List<Entity> entities) {
+    shiftIndices(text, entities, +1);
+  }
+
+  /*
+   * Modify UTF-16-based indices of the entities to Unicode-based indices.
+   *
+   * In Unicode-based indices, Unicode supplementary characters are counted as single characters.
+   *
+   * @param text original text
+   * @param entities entities with UTF-16 based indices
+   */
+  public void modifyIndicesFromUTF16ToToUnicode(String text, List<Entity> entities) {
+    shiftIndices(text, entities, -1);
   }
 
   /*
@@ -346,10 +365,7 @@ public class Extractor {
    * @param entities extracted entities
    * @param the amount to shift the entity's indices.
    */
-  protected void adjustIndices(String text, List<Entity> entities, int diff) {
-    if (!countSupplementaryCharacterAsOne) {
-      return;
-    }
+  protected void shiftIndices(String text, List<Entity> entities, int diff) {
     for (int i = 0; i < text.length() - 1; i++) {
       if (Character.isSupplementaryCodePoint(text.codePointAt(i))) {
         for (Entity entity: entities) {
@@ -368,19 +384,5 @@ public class Extractor {
 
   public boolean isExtractURLWithoutProtocol() {
     return extractURLWithoutProtocol;
-  }
-
-  /**
-   * Specifies whether to count Unicode supplemental characters (which are represented
-   * as 2 characters in Java) as single characters when calculating indices.
-   *
-   * @param flag  true to count supplementary characters as single characters.
-   */
-  public void setCountSupplementaryCharacterAsOne(boolean flag) {
-    this.countSupplementaryCharacterAsOne = flag;
-  }
-
-  public boolean getCountSupplementaryCharacterAsOne() {
-    return countSupplementaryCharacterAsOne;
   }
 }

--- a/tests/com/twitter/AutolinkTest.java
+++ b/tests/com/twitter/AutolinkTest.java
@@ -66,6 +66,13 @@ public class AutolinkTest extends TestCase {
     assertAutolink(expected, linker.autoLink(tweet));
   }
 
+  public void testSupplementaryCharacter() {
+    // 𐐀 = U+10400, a supplementary character.
+    String text = "𐐀 #hashtag 𐐀 @mention 𐐀 http://twitter.com";
+    String expected = "𐐀 <a href=\"http://twitter.com/#!/search?q=%23hashtag\" title=\"#hashtag\" class=\"tweet-url hashtag\" rel=\"nofollow\">#hashtag</a> 𐐀 @<a class=\"tweet-url username\" href=\"http://twitter.com/mention\" rel=\"nofollow\">mention</a> 𐐀 <a href=\"http://twitter.com\" rel=\"nofollow\">http://twitter.com</a>";
+    assertAutolink(expected, linker.autoLink(text));
+  }
+
   protected void assertAutolink(String expected, String linked) {
     assertEquals("Autolinked text should equal the input", expected, linked);
   }

--- a/tests/com/twitter/ExtractorTest.java
+++ b/tests/com/twitter/ExtractorTest.java
@@ -72,25 +72,29 @@ public class ExtractorTest extends TestCase {
       // insert U+10400 before " @mention"
       String text = String.format("%c @mention %c @mention", 0x00010400, 0x00010400);
 
-      // count U+10400 as single character
-      extractor.setCountSupplementaryCharacterAsOne(true);
-      List<Extractor.Entity> extracted = extractor.extractMentionsOrListsWithIndices(text);
-      assertEquals(extracted.size(), 2);
-      assertEquals(extracted.get(0).value, "mention");
-      assertEquals(extracted.get(0).start, 2);
-      assertEquals(extracted.get(0).end, 10);
-      assertEquals(extracted.get(1).value, "mention");
-      assertEquals(extracted.get(1).start, 13);
-      assertEquals(extracted.get(1).end, 21);
-
       // count U+10400 as 2 characters (as in UTF-16)
-      extractor.setCountSupplementaryCharacterAsOne(false);
-      extracted = extractor.extractMentionsOrListsWithIndices(text);
+      List<Extractor.Entity> extracted = extractor.extractMentionsOrListsWithIndices(text);
       assertEquals(extracted.size(), 2);
       assertEquals(extracted.get(0).value, "mention");
       assertEquals(extracted.get(0).start, 3);
       assertEquals(extracted.get(0).end, 11);
       assertEquals(extracted.get(1).value, "mention");
+      assertEquals(extracted.get(1).start, 15);
+      assertEquals(extracted.get(1).end, 23);
+
+      // count U+10400 as single character
+      extractor.modifyIndicesFromUTF16ToToUnicode(text, extracted);
+      assertEquals(extracted.size(), 2);
+      assertEquals(extracted.get(0).start, 2);
+      assertEquals(extracted.get(0).end, 10);
+      assertEquals(extracted.get(1).start, 13);
+      assertEquals(extracted.get(1).end, 21);
+
+      // count U+10400 as 2 characters (as in UTF-16)
+      extractor.modifyIndicesFromUnicodeToUTF16(text, extracted);
+      assertEquals(extracted.size(), 2);
+      assertEquals(extracted.get(0).start, 3);
+      assertEquals(extracted.get(0).end, 11);
       assertEquals(extracted.get(1).start, 15);
       assertEquals(extracted.get(1).end, 23);
     }
@@ -135,25 +139,29 @@ public class ExtractorTest extends TestCase {
       // insert U+10400 before " #hashtag"
       String text = String.format("%c #hashtag %c #hashtag", 0x00010400, 0x00010400);
 
-      // count U+10400 as single character
-      extractor.setCountSupplementaryCharacterAsOne(true);
-      List<Extractor.Entity> extracted = extractor.extractHashtagsWithIndices(text);
-      assertEquals(extracted.size(), 2);
-      assertEquals(extracted.get(0).value, "hashtag");
-      assertEquals(extracted.get(0).start, 2);
-      assertEquals(extracted.get(0).end, 10);
-      assertEquals(extracted.get(1).value, "hashtag");
-      assertEquals(extracted.get(1).start, 13);
-      assertEquals(extracted.get(1).end, 21);
-
       // count U+10400 as 2 characters (as in UTF-16)
-      extractor.setCountSupplementaryCharacterAsOne(false);
-      extracted = extractor.extractHashtagsWithIndices(text);
+      List<Extractor.Entity> extracted = extractor.extractHashtagsWithIndices(text);
       assertEquals(extracted.size(), 2);
       assertEquals(extracted.get(0).value, "hashtag");
       assertEquals(extracted.get(0).start, 3);
       assertEquals(extracted.get(0).end, 11);
       assertEquals(extracted.get(1).value, "hashtag");
+      assertEquals(extracted.get(1).start, 15);
+      assertEquals(extracted.get(1).end, 23);
+
+      // count U+10400 as single character
+      extractor.modifyIndicesFromUTF16ToToUnicode(text, extracted);
+      assertEquals(extracted.size(), 2);
+      assertEquals(extracted.get(0).start, 2);
+      assertEquals(extracted.get(0).end, 10);
+      assertEquals(extracted.get(1).start, 13);
+      assertEquals(extracted.get(1).end, 21);
+
+      // count U+10400 as 2 characters (as in UTF-16)
+      extractor.modifyIndicesFromUnicodeToUTF16(text, extracted);
+      assertEquals(extracted.size(), 2);
+      assertEquals(extracted.get(0).start, 3);
+      assertEquals(extracted.get(0).end, 11);
       assertEquals(extracted.get(1).start, 15);
       assertEquals(extracted.get(1).end, 23);
     }
@@ -215,25 +223,29 @@ public class ExtractorTest extends TestCase {
      // insert U+10400 before " http://twitter.com"
      String text = String.format("%c http://twitter.com %c http://twitter.com", 0x00010400, 0x00010400);
 
-     // count U+10400 as single character
-     extractor.setCountSupplementaryCharacterAsOne(true);
-     List<Extractor.Entity> extracted = extractor.extractURLsWithIndices(text);
-     assertEquals(extracted.size(), 2);
-     assertEquals(extracted.get(0).value, "http://twitter.com");
-     assertEquals(extracted.get(0).start, 2);
-     assertEquals(extracted.get(0).end, 20);
-     assertEquals(extracted.get(1).value, "http://twitter.com");
-     assertEquals(extracted.get(1).start, 23);
-     assertEquals(extracted.get(1).end, 41);
-
      // count U+10400 as 2 characters (as in UTF-16)
-     extractor.setCountSupplementaryCharacterAsOne(false);
-     extracted = extractor.extractURLsWithIndices(text);
+     List<Extractor.Entity> extracted = extractor.extractURLsWithIndices(text);
      assertEquals(extracted.size(), 2);
      assertEquals(extracted.get(0).value, "http://twitter.com");
      assertEquals(extracted.get(0).start, 3);
      assertEquals(extracted.get(0).end, 21);
      assertEquals(extracted.get(1).value, "http://twitter.com");
+     assertEquals(extracted.get(1).start, 25);
+     assertEquals(extracted.get(1).end, 43);
+
+     // count U+10400 as single character
+     extractor.modifyIndicesFromUTF16ToToUnicode(text, extracted);
+     assertEquals(extracted.size(), 2);
+     assertEquals(extracted.get(0).start, 2);
+     assertEquals(extracted.get(0).end, 20);
+     assertEquals(extracted.get(1).start, 23);
+     assertEquals(extracted.get(1).end, 41);
+
+     // count U+10400 as 2 characters (as in UTF-16)
+     extractor.modifyIndicesFromUnicodeToUTF16(text, extracted);
+     assertEquals(extracted.size(), 2);
+     assertEquals(extracted.get(0).start, 3);
+     assertEquals(extracted.get(0).end, 21);
      assertEquals(extracted.get(1).start, 25);
      assertEquals(extracted.get(1).end, 43);
    }

--- a/tests/com/twitter/ExtractorTest.java
+++ b/tests/com/twitter/ExtractorTest.java
@@ -67,6 +67,33 @@ public class ExtractorTest extends TestCase {
       assertEquals(extracted.get(2).getStart().intValue(), 28);
       assertEquals(extracted.get(2).getEnd().intValue(), 34);
     }
+
+    public void testMentionWithSupplementaryCharacters() {
+      // insert U+10400 before " @mention"
+      String text = String.format("%c @mention %c @mention", 0x00010400, 0x00010400);
+
+      // count U+10400 as single character
+      extractor.setCountSupplementaryCharacterAsOne(true);
+      List<Extractor.Entity> extracted = extractor.extractMentionsOrListsWithIndices(text);
+      assertEquals(extracted.size(), 2);
+      assertEquals(extracted.get(0).value, "mention");
+      assertEquals(extracted.get(0).start, 2);
+      assertEquals(extracted.get(0).end, 10);
+      assertEquals(extracted.get(1).value, "mention");
+      assertEquals(extracted.get(1).start, 13);
+      assertEquals(extracted.get(1).end, 21);
+
+      // count U+10400 as 2 characters (as in UTF-16)
+      extractor.setCountSupplementaryCharacterAsOne(false);
+      extracted = extractor.extractMentionsOrListsWithIndices(text);
+      assertEquals(extracted.size(), 2);
+      assertEquals(extracted.get(0).value, "mention");
+      assertEquals(extracted.get(0).start, 3);
+      assertEquals(extracted.get(0).end, 11);
+      assertEquals(extracted.get(1).value, "mention");
+      assertEquals(extracted.get(1).start, 15);
+      assertEquals(extracted.get(1).end, 23);
+    }
   }
 
    /**
@@ -102,6 +129,33 @@ public class ExtractorTest extends TestCase {
       assertEquals(extracted.get(1).getEnd().intValue(), 22);
       assertEquals(extracted.get(2).getStart().intValue(), 28);
       assertEquals(extracted.get(2).getEnd().intValue(), 34);
+    }
+
+    public void testHashtagWithSupplementaryCharacters() {
+      // insert U+10400 before " #hashtag"
+      String text = String.format("%c #hashtag %c #hashtag", 0x00010400, 0x00010400);
+
+      // count U+10400 as single character
+      extractor.setCountSupplementaryCharacterAsOne(true);
+      List<Extractor.Entity> extracted = extractor.extractHashtagsWithIndices(text);
+      assertEquals(extracted.size(), 2);
+      assertEquals(extracted.get(0).value, "hashtag");
+      assertEquals(extracted.get(0).start, 2);
+      assertEquals(extracted.get(0).end, 10);
+      assertEquals(extracted.get(1).value, "hashtag");
+      assertEquals(extracted.get(1).start, 13);
+      assertEquals(extracted.get(1).end, 21);
+
+      // count U+10400 as 2 characters (as in UTF-16)
+      extractor.setCountSupplementaryCharacterAsOne(false);
+      extracted = extractor.extractHashtagsWithIndices(text);
+      assertEquals(extracted.size(), 2);
+      assertEquals(extracted.get(0).value, "hashtag");
+      assertEquals(extracted.get(0).start, 3);
+      assertEquals(extracted.get(0).end, 11);
+      assertEquals(extracted.get(1).value, "hashtag");
+      assertEquals(extracted.get(1).start, 15);
+      assertEquals(extracted.get(1).end, 23);
     }
   }
 
@@ -155,6 +209,33 @@ public class ExtractorTest extends TestCase {
      for (String url : urls) {
        assertEquals(url, extractor.extractURLs(url).get(0));
      }
+   }
+
+   public void testUrlnWithSupplementaryCharacters() {
+     // insert U+10400 before " http://twitter.com"
+     String text = String.format("%c http://twitter.com %c http://twitter.com", 0x00010400, 0x00010400);
+
+     // count U+10400 as single character
+     extractor.setCountSupplementaryCharacterAsOne(true);
+     List<Extractor.Entity> extracted = extractor.extractURLsWithIndices(text);
+     assertEquals(extracted.size(), 2);
+     assertEquals(extracted.get(0).value, "http://twitter.com");
+     assertEquals(extracted.get(0).start, 2);
+     assertEquals(extracted.get(0).end, 20);
+     assertEquals(extracted.get(1).value, "http://twitter.com");
+     assertEquals(extracted.get(1).start, 23);
+     assertEquals(extracted.get(1).end, 41);
+
+     // count U+10400 as 2 characters (as in UTF-16)
+     extractor.setCountSupplementaryCharacterAsOne(false);
+     extracted = extractor.extractURLsWithIndices(text);
+     assertEquals(extracted.size(), 2);
+     assertEquals(extracted.get(0).value, "http://twitter.com");
+     assertEquals(extracted.get(0).start, 3);
+     assertEquals(extracted.get(0).end, 21);
+     assertEquals(extracted.get(1).value, "http://twitter.com");
+     assertEquals(extracted.get(1).start, 25);
+     assertEquals(extracted.get(1).end, 43);
    }
   }
 


### PR DESCRIPTION
Extractor in twitter-text-java extracts entities with UTF-16 based indices where Unicode supplementary characters are counted as two characters.

However, Twitter API and twitter-text-rb produces indices based on Unicode where Unicode supplementary characters are counted as single characters.

This will add 2 new methods, Extractor.modifyIndicesFromUTF16ToUnicode() and Extractor.modifyIndicesFromUnicodeToUTF16(), which can be used to modify indices from UTF-16 based to Unicode based, and vise versa.

This branch is based on origin/punct_before_url (https://github.com/twitter/twitter-text-java/pull/20), which hasn't merged into master yet.
