### PR TITLE
Add latin characters to regex for autolinking hashtags

### DIFF
--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -6,8 +6,8 @@ import java.util.regex.*;
 public class Regex {
   private static String LATIN_ACCENTS_CHARS = "\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u00ff" + // Latin-1
                                               "\\u0100-\\u024f" + // Latin Extended A and B
-                                              "\\u0253\\u0254\\u0256\\u0257\\u0259\\u025b\\u0263\\u0268\\u026f\\u0272\\u0289\\u028b"; // IPA Extensions
-                                              "\\u1e00-\\u1eff" + // Latin Extended Additional (mostly for Vietnamese)
+                                              "\\u0253\\u0254\\u0256\\u0257\\u0259\\u025b\\u0263\\u0268\\u026f\\u0272\\u0289\\u028b" + // IPA Extensions
+                                              "\\u1e00-\\u1eff"; // Latin Extended Additional (mostly for Vietnamese)
   private static final String HASHTAG_ALPHA_CHARS = "a-z" + LATIN_ACCENTS_CHARS +
                                                    "\\u0400-\\u04ff\\u0500-\\u0527" +  // Cyrillic
                                                    "\\u2de0–\\u2dff\\ua640–\\ua69f" +  // Cyrillic Extended A/B

--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -4,7 +4,7 @@ package com.twitter;
 import java.util.regex.*;
 
 public class Regex {
-  private static String LATIN_ACCENTS_CHARS = "\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u00ff\\u015f";
+  private static String LATIN_ACCENTS_CHARS = "\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u024f\\u0253\\u0254\\u0256\\u0257\\u0259\\u025b\\u0263\\u0268\\u026f\\u0272\\u0289\\u028b";
   private static final String HASHTAG_ALPHA_CHARS = "a-z" + LATIN_ACCENTS_CHARS +
                                                    "\\u0400-\\u04ff\\u0500-\\u0527" +  // Cyrillic
                                                    "\\u2de0–\\u2dff\\ua640–\\ua69f" +  // Cyrillic Extended A/B

--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -4,7 +4,10 @@ package com.twitter;
 import java.util.regex.*;
 
 public class Regex {
-  private static String LATIN_ACCENTS_CHARS = "\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u024f\\u0253\\u0254\\u0256\\u0257\\u0259\\u025b\\u0263\\u0268\\u026f\\u0272\\u0289\\u028b";
+  private static String LATIN_ACCENTS_CHARS = "\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u00ff" + // Latin-1
+                                              "\\u0100-\\u024f" + // Latin Extended A and B
+                                              "\\u0253\\u0254\\u0256\\u0257\\u0259\\u025b\\u0263\\u0268\\u026f\\u0272\\u0289\\u028b"; // IPA Extensions
+                                              "\\u1e00-\\u1eff" + // Latin Extended Additional (mostly for Vietnamese)
   private static final String HASHTAG_ALPHA_CHARS = "a-z" + LATIN_ACCENTS_CHARS +
                                                    "\\u0400-\\u04ff\\u0500-\\u0527" +  // Cyrillic
                                                    "\\u2de0–\\u2dff\\ua640–\\ua69f" +  // Cyrillic Extended A/B

--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -7,6 +7,7 @@ public class Regex {
   private static String LATIN_ACCENTS_CHARS = "\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u00ff" + // Latin-1
                                               "\\u0100-\\u024f" + // Latin Extended A and B
                                               "\\u0253\\u0254\\u0256\\u0257\\u0259\\u025b\\u0263\\u0268\\u026f\\u0272\\u0289\\u028b" + // IPA Extensions
+                                              "\\u02bb" + // Hawaiian
                                               "\\u1e00-\\u1eff"; // Latin Extended Additional (mostly for Vietnamese)
   private static final String HASHTAG_ALPHA_CHARS = "a-z" + LATIN_ACCENTS_CHARS +
                                                    "\\u0400-\\u04ff\\u0500-\\u0527" +  // Cyrillic

--- a/tests/com/twitter/RegexTest.java
+++ b/tests/com/twitter/RegexTest.java
@@ -7,6 +7,9 @@ import junit.framework.TestCase;
 public class RegexTest extends TestCase {
   public void testAutoLinkHashtags() {
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#hashtag");
+    assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#Azərbaycanca");
+    assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#mûǁae");
+    assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#Čeština");
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#caf\u00E9");
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#日本語ハッシュタグ");
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "＃日本語ハッシュタグ");

--- a/tests/com/twitter/RegexTest.java
+++ b/tests/com/twitter/RegexTest.java
@@ -10,6 +10,8 @@ public class RegexTest extends TestCase {
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#Azərbaycanca");
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#mûǁae");
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#Čeština");
+    assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#Ċaoiṁín");
+    assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#Caoiṁín");
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#caf\u00E9");
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#日本語ハッシュタグ");
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "＃日本語ハッシュタグ");


### PR DESCRIPTION
This patch adds Latin characters needed for hashtags in several languages with large, active Twitter communities, notably Vietnamese, Romanian, Polish, Czech, Croatian, and Turkish.  The only tricky thing was how to handle the "IPA Extensions" Unicode block; I chose not to add all of the letter characters from this block since the majority are only used for linguistic transcription - a handful of characters, however, are used in standard written alphabets in Africa, e.g. ɓ, ɗ in Hausa (~40 million speakers), ɔ and ɛ Akan (national language in Ghana) and Lingala; 12 in all.
