### PR TITLE
Allow maqaf, geresh, gershayim in hashtags

### DIFF
--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -12,8 +12,8 @@ public class Regex {
   private static final String HASHTAG_ALPHA_CHARS = "a-z" + LATIN_ACCENTS_CHARS +
                                                    "\\u0400-\\u04ff\\u0500-\\u0527" +  // Cyrillic
                                                    "\\u2de0-\\u2dff\\ua640-\\ua69f" +  // Cyrillic Extended A/B
-                                                   "\\u0591-\\u05bd\\u05bf\\u05c1-\\u05c2\\u05c4-\\u05c5\\u05c7" +
-                                                   "\\u05d0-\\u05ea\\u05f0-\\u05f2" + // Hebrew
+                                                   "\\u0591-\\u05bf\\u05c1-\\u05c2\\u05c4-\\u05c5\\u05c7" +
+                                                   "\\u05d0-\\u05ea\\u05f0-\\u05f4" + // Hebrew
                                                    "\\ufb1d-\\ufb28\\ufb2a-\\ufb36\\ufb38-\\ufb3c\\ufb3e\\ufb40-\\ufb41" +
                                                    "\\ufb43-\\ufb44\\ufb46-\\ufb4f" + // Hebrew Pres. Forms
                                                    "\\u0610-\\u061a\\u0620-\\u065f\\u066e-\\u06d3\\u06d5-\\u06dc" +

--- a/tests/com/twitter/RegexTest.java
+++ b/tests/com/twitter/RegexTest.java
@@ -15,6 +15,9 @@ public class RegexTest extends TestCase {
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#caf\u00E9");
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#\u05e2\u05d1\u05e8\u05d9\u05ea"); // "#Hebrew"
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#\u05d0\u05b2\u05e9\u05b6\u05c1\u05e8"); // with marks
+    assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#\u05e2\u05b7\u05dc\u05be\u05d9\u05b0\u05d3\u05b5\u05d9"); // with maqaf 05be
+    assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#\u05d5\u05db\u05d5\u05f3"); // with geresh 05f3
+    assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#\u05de\u05f4\u05db"); // with gershayim 05f4
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#\u0627\u0644\u0639\u0631\u0628\u064a\u0629"); // "#Arabic"
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#\u062d\u0627\u0644\u064a\u0627\u064b"); // with mark
     assertCaptureCount(3, Regex.AUTO_LINK_HASHTAGS, "#\u064a\u0640\ufbb1\u0640\u064e\u0671"); // with pres. form


### PR DESCRIPTION
This will allow selected Hebrew punctuation to appear in hashtags, as requested by international team.
