### PR TITLE
Add new options to Autolink

### DIFF
--- a/src/com/twitter/Autolink.java
+++ b/src/com/twitter/Autolink.java
@@ -43,6 +43,7 @@ public class Autolink {
   protected boolean usernameIncludeSymbol = false;
   protected String symbolTag = null;
   protected String textWithSymbolTag = null;
+  protected String urlTarget = null;
 
   private Extractor extractor = new Extractor();
 
@@ -245,6 +246,9 @@ public class Autolink {
     builder.append("<a href=\"").append(url).append("\"");
     if (urlClass != null && !urlClass.isEmpty()) {
       builder.append(" class=\"").append(urlClass).append("\"");
+    }
+    if (urlTarget != null && !urlTarget.isEmpty()) {
+      builder.append(" target=\"").append(urlTarget).append("\"");
     }
     if (noFollow){
       builder.append(NO_FOLLOW_HTML_ATTRIBUTE);
@@ -525,5 +529,14 @@ public class Autolink {
    */
   public void setTextWithSymbolTag(String tag) {
     this.textWithSymbolTag = tag;
+  }
+
+  /**
+   * Set the value of the target attribute in auto-linked URLs
+   *
+   * @param target target value e.g., "_blank"
+   */
+  public void setUrlTarget(String target) {
+    this.urlTarget = target;
   }
 }

--- a/src/com/twitter/Autolink.java
+++ b/src/com/twitter/Autolink.java
@@ -29,9 +29,13 @@ public class Autolink {
   /** Default attribute for invisible span tag */
   public static final String DEFAULT_INVISIBLE_TAG_ATTRS = "style='position:absolute;left:-9999px;'";
 
-  public static interface HtmlAttributeModifier {
+  public static interface LinkAttributeModifier {
     public void modify(Entity entity, Map<String, String> attributes);
   };
+
+  public static interface LinkTextModifier {
+    public CharSequence modify(Entity entity, CharSequence text);
+  }
 
   protected String urlClass = null;
   protected String listClass;
@@ -48,7 +52,8 @@ public class Autolink {
   protected String symbolTag = null;
   protected String textWithSymbolTag = null;
   protected String urlTarget = null;
-  protected HtmlAttributeModifier htmlAttributeModifier = null;
+  protected LinkAttributeModifier linkAttributeModifier = null;
+  protected LinkTextModifier linkTextModifier = null;
 
   private Extractor extractor = new Extractor();
 
@@ -105,8 +110,11 @@ public class Autolink {
     if (noFollow) {
       attributes.put("rel", "nofollow");
     }
-    if (htmlAttributeModifier != null) {
-      htmlAttributeModifier.modify(entity, attributes);
+    if (linkAttributeModifier != null) {
+      linkAttributeModifier.modify(entity, attributes);
+    }
+    if (linkTextModifier != null) {
+      text = linkTextModifier.modify(entity, text);
     }
     // append <a> tag
     builder.append("<a");
@@ -538,11 +546,20 @@ public class Autolink {
   }
 
   /**
-   * Set a modifier to modify HTML attributes based on entity
+   * Set a modifier to modify attributes of a link based on an entity
    *
-   * @param modifier HtmlAttributeModifier instance
+   * @param modifier LinkAttributeModifier instance
    */
-  public void setHtmlAttributeModifier(HtmlAttributeModifier modifier) {
-    this.htmlAttributeModifier = modifier;
+  public void setLinkAttributeModifier(LinkAttributeModifier modifier) {
+    this.linkAttributeModifier = modifier;
+  }
+
+  /**
+   * Set a modifier to modify text of a link based on an entity
+   *
+   * @param modifier LinkTextModifier instance
+   */
+  public void setLinkTextModifier(LinkTextModifier modifier) {
+    this.linkTextModifier = modifier;
   }
 }

--- a/src/com/twitter/Autolink.java
+++ b/src/com/twitter/Autolink.java
@@ -8,16 +8,14 @@ import java.util.List;
  * A class for adding HTML links to hashtag, username and list references in Tweet text.
  */
 public class Autolink {
-  /** Default CSS class for auto-linked URLs */
-  public static final String DEFAULT_URL_CLASS = "tweet-url";
   /** Default CSS class for auto-linked list URLs */
-  public static final String DEFAULT_LIST_CLASS = "list-slug";
+  public static final String DEFAULT_LIST_CLASS = "tweet-url list-slug";
   /** Default CSS class for auto-linked username URLs */
-  public static final String DEFAULT_USERNAME_CLASS = "username";
+  public static final String DEFAULT_USERNAME_CLASS = "tweet-url username";
   /** Default CSS class for auto-linked hashtag URLs */
-  public static final String DEFAULT_HASHTAG_CLASS = "hashtag";
+  public static final String DEFAULT_HASHTAG_CLASS = "tweet-url hashtag";
   /** Default CSS class for auto-linked cashtag URLs */
-  public static final String DEFAULT_CASHTAG_CLASS = "cashtag";
+  public static final String DEFAULT_CASHTAG_CLASS = "tweet-url cashtag";
   /** Default href for username links (the username without the @ will be appended) */
   public static final String DEFAULT_USERNAME_URL_BASE = "https://twitter.com/";
   /** Default href for list links (the username/list without the @ will be appended) */
@@ -62,7 +60,7 @@ public class Autolink {
   }
 
   public Autolink() {
-    urlClass = DEFAULT_URL_CLASS;
+    urlClass = null;
     listClass = DEFAULT_LIST_CLASS;
     usernameClass = DEFAULT_USERNAME_CLASS;
     hashtagClass = DEFAULT_HASHTAG_CLASS;
@@ -100,7 +98,7 @@ public class Autolink {
 
     builder.append("<a href=\"").append(hashtagUrlBase).append(entity.getValue()).append("\"");
     builder.append(" title=\"#").append(entity.getValue()).append("\"");
-    builder.append(" class=\"").append(urlClass).append(" ").append(hashtagClass).append("\"");
+    builder.append(" class=\"").append(hashtagClass).append("\"");
     if (noFollow) {
       builder.append(NO_FOLLOW_HTML_ATTRIBUTE);
     }
@@ -117,7 +115,7 @@ public class Autolink {
     if (!usernameIncludeSymbol) {
       builder.append(atChar);
     }
-    builder.append("<a class=\"").append(urlClass).append(" ");
+    builder.append("<a class=\"");
     if (entity.listSlug != null) {
       // this is list
       builder.append(listClass).append("\" href=\"").append(listUrlBase);
@@ -204,6 +202,9 @@ public class Autolink {
     }
 
     builder.append("<a href=\"").append(url).append("\"");
+    if (urlClass != null && !urlClass.isEmpty()) {
+      builder.append(" class=\"").append(urlClass).append("\"");
+    }
     if (noFollow){
       builder.append(NO_FOLLOW_HTML_ATTRIBUTE);
     }
@@ -213,7 +214,7 @@ public class Autolink {
   public void linkToCashtag(Entity entity, String text, StringBuilder builder) {
     builder.append("<a href=\"").append(cashtagUrlBase).append(entity.getValue()).append("\"");
     builder.append(" title=\"$").append(entity.getValue()).append("\"");
-    builder.append(" class=\"").append(urlClass).append(" ").append(cashtagClass).append("\"");
+    builder.append(" class=\"").append(cashtagClass).append("\"");
     if (noFollow) {
       builder.append(NO_FOLLOW_HTML_ATTRIBUTE);
     }

--- a/src/com/twitter/Autolink.java
+++ b/src/com/twitter/Autolink.java
@@ -508,4 +508,22 @@ public class Autolink {
   public void setUsernameIncludeSymbol(boolean usernameIncludeSymbol) {
     this.usernameIncludeSymbol = usernameIncludeSymbol;
   }
+
+  /**
+   * Set HTML tag to be applied around #/@/# symbols in hashtags/usernames/lists/cashtag
+   *
+   * @param tag HTML tag without bracket. e.g., "b" or "s"
+   */
+  public void setSymbolTag(String tag) {
+    this.symbolTag = tag;
+  }
+
+  /**
+   * Set HTML tag to be applied around text part of hashtags/usernames/lists/cashtag
+   *
+   * @param tag HTML tag without bracket. e.g., "b" or "s"
+   */
+  public void setTextWithSymbolTag(String tag) {
+    this.textWithSymbolTag = tag;
+  }
 }

--- a/tests/com/twitter/AutolinkTest.java
+++ b/tests/com/twitter/AutolinkTest.java
@@ -81,6 +81,24 @@ public class AutolinkTest extends TestCase {
     assertAutolink(expected, linker.autoLink(tweet));
   }
 
+  public void testUrlClass() {
+    linker.setNoFollow(false);
+
+    String tweet = "http://twitter.com";
+    String expected = "<a href=\"http://twitter.com\">http://twitter.com</a>";
+    assertAutolink(expected, linker.autoLink(tweet));
+
+    linker.setUrlClass("testClass");
+    expected = "<a href=\"http://twitter.com\" class=\"testClass\">http://twitter.com</a>";
+    assertAutolink(expected, linker.autoLink(tweet));
+
+    tweet = "#hash @tw";
+    String result = linker.autoLink(tweet);
+    assertTrue(result.contains("class=\"" + Autolink.DEFAULT_HASHTAG_CLASS + "\""));
+    assertTrue(result.contains("class=\"" + Autolink.DEFAULT_USERNAME_CLASS + "\""));
+    assertFalse(result.contains("class=\"testClass\""));
+  }
+
   protected void assertAutolink(String expected, String linked) {
     assertEquals("Autolinked text should equal the input", expected, linked);
   }

--- a/tests/com/twitter/AutolinkTest.java
+++ b/tests/com/twitter/AutolinkTest.java
@@ -99,6 +99,24 @@ public class AutolinkTest extends TestCase {
     assertFalse(result.contains("class=\"testClass\""));
   }
 
+  public void testSymbolTag() {
+    linker.setSymbolTag("s");
+    linker.setTextWithSymbolTag("b");
+    linker.setNoFollow(false);
+
+    String tweet = "#hash";
+    String expected = "<a href=\"https://twitter.com/#!/search?q=%23hash\" title=\"#hash\" class=\"tweet-url hashtag\"><s>#</s><b>hash</b></a>";
+    assertAutolink(expected, linker.autoLink(tweet));
+
+    tweet = "@mention";
+    expected = "<s>@</s><a class=\"tweet-url username\" href=\"https://twitter.com/mention\"><b>mention</b></a>";
+    assertAutolink(expected, linker.autoLink(tweet));
+
+    linker.setUsernameIncludeSymbol(true);
+    expected = "<a class=\"tweet-url username\" href=\"https://twitter.com/mention\"><s>@</s><b>mention</b></a>";
+    assertAutolink(expected, linker.autoLink(tweet));
+  }
+
   protected void assertAutolink(String expected, String linked) {
     assertEquals("Autolinked text should equal the input", expected, linked);
   }

--- a/tests/com/twitter/AutolinkTest.java
+++ b/tests/com/twitter/AutolinkTest.java
@@ -3,6 +3,7 @@ package com.twitter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import com.twitter.Extractor.Entity;
 
@@ -115,6 +116,17 @@ public class AutolinkTest extends TestCase {
     linker.setUsernameIncludeSymbol(true);
     expected = "<a class=\"tweet-url username\" href=\"https://twitter.com/mention\"><s>@</s><b>mention</b></a>";
     assertAutolink(expected, linker.autoLink(tweet));
+  }
+
+  public void testUrlTarget() {
+    linker.setUrlTarget("_blank");
+
+    String tweet = "http://test.com";
+    String result = linker.autoLink(tweet);
+    assertFalse("urlTarget shouldn't be applied to auto-linked hashtag", Pattern.matches(".*<a[^>]+hashtag[^>]+target[^>]+>.*", result));
+    assertFalse("urlTarget shouldn't be applied to auto-linked mention", Pattern.matches(".*<a[^>]+username[^>]+target[^>]+>.*", result));
+    assertTrue("urlTarget should be applied to auto-linked URL", Pattern.matches(".*<a[^>]+test.com[^>]+target=\"_blank\"[^>]*>.*", result));
+    assertFalse("urlClass should not appear in HTML", result.toLowerCase().contains("urlclass"));
   }
 
   protected void assertAutolink(String expected, String linked) {


### PR DESCRIPTION
This will add the following options to Autolink.
- symbolTag: a tag to apply around symbol (#,@,$) in hashtag/username/list/cashtag links. 
- textWithSymbolTag: a tag to apply around text part in hashtag/username/list/cashtag links.
- urlTarget: the value of target attribute in URL links
- linkAttributeModifier: modifies attributes of a link based on the entity.
- linkTextModifier: modifies text of a link based on the entity.

Examples:

```
  linker.setSymbolTag("s"); linker.autoLink("#hash") => "<a...><s>#</s>hash</a>"

  linker.setTextWithSymbolTag("b"); linker.autoLink("#hash") => "<a...>#<b>hash</b></a>"

  linker.setLinkAttributeModifier(new LinkAttributeModifier() {
    @Override public void modify(Entity entity, Map<String, String> attributes) {
      if (entity.type == Type.HASHTAG) attributes.put("custom-attr", "some_value");
     });
  linker.autoLink("#hash") => "<a.. custom-attr="some_value"...>#hash</a>"
  linker.setLinkTextModifier(new LinkTextModifier() {
    @Override public CharSequence modify(Entity entity, CharSequence text) {
      return entity.type == Type.HASHTAG ? "prefix"+text : text;
     });
  autoLink("#hash") => "<a...>prefix#text</a>"
```

This will also change urlClass option, which is currently applied to all links but will only be applied to URL links.
