### PR TITLE
Fix scope of dependency org.yaml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,7 @@
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
       <version>1.12</version>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
Add scope "test" to org.yaml-dependency as yaml is only used in a test class.
