### PR TITLE
Don't rely on getSystemResourceAsStream to retrieve tld_lib.yml

### DIFF
--- a/src/com/twitter/Regex.java
+++ b/src/com/twitter/Regex.java
@@ -25,7 +25,7 @@ public class Regex {
 
   private static final Yaml yaml = new Yaml();
   private static final Map tlds = (Map)yaml.load(
-    ClassLoader.getSystemResourceAsStream("tld_lib.yml")
+    Regex.class.getClassLoader().getResourceAsStream("tld_lib.yml")
   );
   private static final List gTlds = (List)tlds.get("generic");
   private static final List cTlds = (List)tlds.get("country");


### PR DESCRIPTION
Let the ClassLoader which has loaded ourself load the YAML resource instead.
This is vital for environments such as application containers, Android, etc. where non-default ClassLoader should be used.
